### PR TITLE
MySQL, spelling and MariaDBJava Connector fixes for Ansible scripts

### DIFF
--- a/setup/main.yml
+++ b/setup/main.yml
@@ -11,7 +11,7 @@
       sha256sum: 2cc244070d01193c541e526564068e6f4e9ecade22380e38e681e931f3dc3699
       mariadb:
         version: 1.1.7
-        sha256sum: ff0b807b9209fbd5e05d62152006f6a43868ba7f55bb9716035dc6d8a5382390
+        checksum: md5:1d779d93425b82f01757bf6f7b82379f
     idp:
       version: 2.4.3
       sha256sum: 23cd7b5170c36add811939e225f049f1505b9a02be3a1a5d6937761a0b23868b

--- a/setup/tasks/app.yml
+++ b/setup/tasks/app.yml
@@ -120,7 +120,7 @@
     group: root
     mode: 0600
 
-- meta: flush_handers
+- meta: flush_handlers
 
 - name: 'Enable SPIN service'
   service:

--- a/setup/tasks/db.yml
+++ b/setup/tasks/db.yml
@@ -27,8 +27,7 @@
 
 - name: 'Generate MariaDB root password'
   set_fact:
-    mariadb_password: >
-      {{ lookup('password', '../passwords/mariadb_password chars=letters,digits length=64') }}
+    mariadb_password: "{{ lookup('password', '../passwords/mariadb_password chars=letters,digits length=64') }}"
 
 - name: 'Create lock_down_db.sql'
   template:

--- a/setup/tasks/tomcat.yml
+++ b/setup/tasks/tomcat.yml
@@ -22,12 +22,13 @@
 
 - name: 'Download MariaDB connector library'
   get_url:
-    url: 'http://mirror.aarnet.edu.au/pub/MariaDB/client-java-{{ tomcat.mariadb.version }}/mariadb-java-client-{{ tomcat.mariadb.version }}.jar'
+    url: 'http://archive.mariadb.org/client-java-{{ tomcat.mariadb.version }}/mariadb-java-client-{{ tomcat.mariadb.version }}.jar'
     dest: '/opt/spin/downloads/mariadb-java-client-{{ tomcat.mariadb.version }}.jar'
-    sha256sum: '{{ tomcat.mariadb.sha256sum }}'
+    checksum: '{{ tomcat.mariadb.checksum }}'
     owner: root
     group: spin
     mode: 0640
+
 
 - name: 'Symlink MariaDB connector library'
   file:


### PR DESCRIPTION
## Fixes:
### db.yml: 
#### Previous Issue (now fixed): 
- Additional whitespace occurs next to but within the generated root db password sections of the lock_down_db.sql file.   
----
### app.yml: 
#### Previous Issue (now fixed): 
-  spelling error for _flush_handlers_  
----
### main.yml and tomcat.yml: 
#### Previous Issue: 
-  AARNET mirror  not longer provides any MariaDB Java Connectors. 
#### Fixes:
- Retrieves the MariaDB Java Connector from archive.mariadb.org
- Changed to match MD5 checksum instead of SHA256 sum as archive.mariadb.org only provides the MD5 checksum
